### PR TITLE
Add electron interface for warehouse simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+__pycache__/
+*.pyc
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Stock Simulator
 
-Status : Under Development
+Status: Under Development
 
-This tool is an Simpy simulatool to simulate the inventory in a warehouse.
+This tool uses [simpy](https://simpy.readthedocs.io/) to simulate warehouse inventory and order flows. A simple Electron interface can be used to run the Python simulation and view its output.
 
-A set of articles needs to be defined and then allocated to a specific warehouse.
+## Running the Electron app
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+2. Start the application:
+   ```bash
+   npm start
+   ```
+
+Click **Run Simulation** to execute the Python script and stream the output.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Warehouse Simulator</title>
+</head>
+<body>
+  <h1>Warehouse Simulator</h1>
+  <button id="run-btn">Run Simulation</button>
+  <pre id="output"></pre>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,27 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "warehouse-simulator-electron",
+  "version": "0.1.0",
+  "main": "main.js",
+  "description": "Electron interface for warehouse simulation",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^27.0.0"
+  }
+}

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,20 @@
+const { spawn } = require('child_process');
+
+document.getElementById('run-btn').addEventListener('click', () => {
+  const output = document.getElementById('output');
+  output.textContent = 'Running...\n';
+
+  const sim = spawn('python', ['simulation.py']);
+
+  sim.stdout.on('data', (data) => {
+    output.textContent += data.toString();
+  });
+
+  sim.stderr.on('data', (data) => {
+    output.textContent += data.toString();
+  });
+
+  sim.on('close', (code) => {
+    output.textContent += `\nSimulation finished with code ${code}`;
+  });
+});


### PR DESCRIPTION
## Summary
- add Electron project scaffolding with package.json
- create Electron main process and renderer
- include simple HTML interface
- document how to run the Electron app
- add .gitignore for node and python artifacts

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/electron)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684373a79e58832c96ae46c10dfb247d