### PR TITLE
Fix Electron ESM bootstrap

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -1,0 +1,3 @@
+(async () => {
+  await import('./main.mjs');
+})();

--- a/main.mjs
+++ b/main.mjs
@@ -1,5 +1,9 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Create the main application window
 function createWindow() {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "warehouse_simulator",
   "version": "1.0.0",
   "description": "A minimal demo of a warehouse inventory simulation built with Node.js and Python.",
-  "main": "main.js",
+  "main": "main.cjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron ."


### PR DESCRIPTION
## Summary
- load ESM entry via a CJS shim
- convert `main.js` to `main.mjs`
- reference the new entry point from `package.json`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684376d185f0832cb5669c04f2e6e684