### PR TITLE
Fix preload script to run in Electron

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -11,7 +11,7 @@ function createWindow() {
     width: 800,
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, 'preload.cjs'),
     },
   });
 

--- a/preload.cjs
+++ b/preload.cjs
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+const { contextBridge, ipcRenderer } = require('electron');
 
 // Expose a safe API to the renderer
 contextBridge.exposeInMainWorld('api', {


### PR DESCRIPTION
## Summary
- rename `preload.js` to `preload.cjs`
- load the CommonJS preload script from Electron

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68437845d2e4832cbca4d968d8be2f93