### PR TITLE
Add entity CRUD management

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,21 @@
 </head>
 <body>
   <h1>Supply Chain Simulator</h1>
+  <div id="entityForm">
+    <input id="entityId" placeholder="ID" />
+    <input id="entityName" placeholder="Name" />
+    <input id="entityLocation" placeholder="Location" />
+    <select id="entityType">
+      <option value="supplier">Supplier</option>
+      <option value="manufacturer">Manufacturer</option>
+      <option value="warehouse">Warehouse</option>
+      <option value="distributor">Distributor</option>
+      <option value="retailer">Retailer</option>
+    </select>
+    <button id="createEntity">Add</button>
+    <button id="updateEntity">Update</button>
+    <button id="deleteEntity">Delete</button>
+  </div>
   <button id="addEntity">Add Sample Entity</button>
   <button id="nextStep">Next Step</button>
   <pre id="output"></pre>

--- a/main.mjs
+++ b/main.mjs
@@ -32,7 +32,7 @@ app.on('window-all-closed', () => {
 
 // IPC handlers bridging to simulator modules
 import { nextStep, addEntity } from './simulator/simulation.js';
-import { getEntities } from './simulator/entities.js';
+import { getEntities, updateEntity, deleteEntity } from './simulator/entities.js';
 
 ipcMain.handle('sim:addEntity', (_event, entity) => {
   return addEntity(entity);
@@ -40,6 +40,14 @@ ipcMain.handle('sim:addEntity', (_event, entity) => {
 
 ipcMain.handle('sim:getEntities', () => {
   return getEntities();
+});
+
+ipcMain.handle('sim:updateEntity', (_event, id, partial) => {
+  return updateEntity(id, partial);
+});
+
+ipcMain.handle('sim:deleteEntity', (_event, id) => {
+  return deleteEntity(id);
 });
 
 ipcMain.handle('sim:nextStep', () => {

--- a/preload.cjs
+++ b/preload.cjs
@@ -3,6 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 // Expose a safe API to the renderer
 contextBridge.exposeInMainWorld('api', {
   addEntity: (entity) => ipcRenderer.invoke('sim:addEntity', entity),
+  updateEntity: (id, partial) => ipcRenderer.invoke('sim:updateEntity', id, partial),
+  deleteEntity: (id) => ipcRenderer.invoke('sim:deleteEntity', id),
   getEntities: () => ipcRenderer.invoke('sim:getEntities'),
   nextStep: () => ipcRenderer.invoke('sim:nextStep'),
 });

--- a/renderer.js
+++ b/renderer.js
@@ -5,6 +5,15 @@ const output = document.getElementById('output');
 const canvas = document.getElementById('entityCanvas');
 const ctx = canvas.getContext('2d');
 
+// Form elements for entity management
+const createBtn = document.getElementById('createEntity');
+const updateBtn = document.getElementById('updateEntity');
+const deleteBtn = document.getElementById('deleteEntity');
+const idInput = document.getElementById('entityId');
+const nameInput = document.getElementById('entityName');
+const locationInput = document.getElementById('entityLocation');
+const typeSelect = document.getElementById('entityType');
+
 function drawEntities(entities) {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   entities.forEach((e, idx) => {
@@ -17,12 +26,16 @@ function drawEntities(entities) {
   });
 }
 
-addBtn.addEventListener('click', async () => {
-  const sample = { id: Date.now().toString(), type: 'warehouse', name: 'Temp Warehouse', location: 'Unknown' };
-  await window.api.addEntity(sample);
+async function refresh() {
   const entities = await window.api.getEntities();
   output.textContent = JSON.stringify(entities, null, 2);
   drawEntities(entities);
+}
+
+addBtn.addEventListener('click', async () => {
+  const sample = { id: Date.now().toString(), type: 'warehouse', name: 'Temp Warehouse', location: 'Unknown' };
+  await window.api.addEntity(sample);
+  refresh();
 });
 
 stepBtn.addEventListener('click', async () => {
@@ -30,4 +43,32 @@ stepBtn.addEventListener('click', async () => {
   output.textContent = JSON.stringify(state, null, 2);
   const entities = await window.api.getEntities();
   drawEntities(entities);
+});
+
+createBtn.addEventListener('click', async () => {
+  const entity = {
+    id: idInput.value || Date.now().toString(),
+    name: nameInput.value,
+    location: locationInput.value,
+    type: typeSelect.value,
+  };
+  await window.api.addEntity(entity);
+  refresh();
+});
+
+updateBtn.addEventListener('click', async () => {
+  if (!idInput.value) return;
+  const partial = {
+    name: nameInput.value,
+    location: locationInput.value,
+    type: typeSelect.value,
+  };
+  await window.api.updateEntity(idInput.value, partial);
+  refresh();
+});
+
+deleteBtn.addEventListener('click', async () => {
+  if (!idInput.value) return;
+  await window.api.deleteEntity(idInput.value);
+  refresh();
 });

--- a/simulator/entities.js
+++ b/simulator/entities.js
@@ -2,6 +2,15 @@ import fs from 'fs';
 import path from 'path';
 const dataPath = path.join(process.cwd(), 'data', 'entities.json');
 
+// Allowed entity types for validation
+export const ALLOWED_TYPES = [
+  'supplier',
+  'manufacturer',
+  'warehouse',
+  'distributor',
+  'retailer',
+];
+
 function readData() {
   if (!fs.existsSync(dataPath)) return [];
   return JSON.parse(fs.readFileSync(dataPath));
@@ -16,6 +25,9 @@ export function getEntities() {
 }
 
 export function addEntity(entity) {
+  if (!ALLOWED_TYPES.includes(entity.type)) {
+    throw new Error(`Invalid entity type: ${entity.type}`);
+  }
   const data = readData();
   data.push(entity);
   writeData(data);
@@ -26,7 +38,11 @@ export function updateEntity(id, partial) {
   const data = readData();
   const idx = data.findIndex(e => e.id === id);
   if (idx !== -1) {
-    data[idx] = { ...data[idx], ...partial };
+    const updated = { ...data[idx], ...partial };
+    if (updated.type && !ALLOWED_TYPES.includes(updated.type)) {
+      throw new Error(`Invalid entity type: ${updated.type}`);
+    }
+    data[idx] = updated;
     writeData(data);
     return data[idx];
   }


### PR DESCRIPTION
## Summary
- add allowed entity types and validation logic
- expose CRUD IPC handlers and methods for entities
- build form inputs for editing entities
- handle create/update/delete events in renderer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684379db1d44832caa3ebdc880b82b0d