### PR TITLE
Implement inventory management API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,7 @@ npm install   # install Electron
 npm start     # launch the desktop app
 ```
 
-Use the buttons in the UI to add a sample entity or advance the simulation
-step. The current state will be printed on screen for debugging.
+Use the buttons in the UI to add a sample entity, advance the simulation
+step, or view current inventory levels. Inventory is automatically reduced
+from the source when an order is placed and added to the destination once
+the order is fulfilled.

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <h1>Supply Chain Simulator</h1>
   <button id="addEntity">Add Sample Entity</button>
   <button id="nextStep">Next Step</button>
+  <button id="viewInventory">View Inventory</button>
   <pre id="output"></pre>
   <canvas id="entityCanvas" width="600" height="400" style="border:1px solid #ccc"></canvas>
   <script type="module" src="renderer.js"></script>

--- a/main.mjs
+++ b/main.mjs
@@ -33,6 +33,7 @@ app.on('window-all-closed', () => {
 // IPC handlers bridging to simulator modules
 import { nextStep, addEntity } from './simulator/simulation.js';
 import { getEntities } from './simulator/entities.js';
+import { getAllInventory } from './simulator/inventory.js';
 
 ipcMain.handle('sim:addEntity', (_event, entity) => {
   return addEntity(entity);
@@ -44,4 +45,8 @@ ipcMain.handle('sim:getEntities', () => {
 
 ipcMain.handle('sim:nextStep', () => {
   return nextStep();
+});
+
+ipcMain.handle('sim:getAllInventory', () => {
+  return getAllInventory();
 });

--- a/preload.cjs
+++ b/preload.cjs
@@ -5,4 +5,5 @@ contextBridge.exposeInMainWorld('api', {
   addEntity: (entity) => ipcRenderer.invoke('sim:addEntity', entity),
   getEntities: () => ipcRenderer.invoke('sim:getEntities'),
   nextStep: () => ipcRenderer.invoke('sim:nextStep'),
+  getAllInventory: () => ipcRenderer.invoke('sim:getAllInventory'),
 });

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,7 @@
 // Handle UI events and interact with backend via preload API
 const addBtn = document.getElementById('addEntity');
 const stepBtn = document.getElementById('nextStep');
+const inventoryBtn = document.getElementById('viewInventory');
 const output = document.getElementById('output');
 const canvas = document.getElementById('entityCanvas');
 const ctx = canvas.getContext('2d');
@@ -27,7 +28,13 @@ addBtn.addEventListener('click', async () => {
 
 stepBtn.addEventListener('click', async () => {
   const state = await window.api.nextStep();
-  output.textContent = JSON.stringify(state, null, 2);
+  const inventory = await window.api.getAllInventory();
+  output.textContent = JSON.stringify({ state, inventory }, null, 2);
   const entities = await window.api.getEntities();
   drawEntities(entities);
+});
+
+inventoryBtn.addEventListener('click', async () => {
+  const inventory = await window.api.getAllInventory();
+  output.textContent = JSON.stringify(inventory, null, 2);
 });

--- a/simulator/inventory.js
+++ b/simulator/inventory.js
@@ -11,6 +11,10 @@ function writeData(data) {
   fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
 }
 
+export function getAllInventory() {
+  return readData();
+}
+
 export function getInventory(id) {
   const data = readData();
   return data[id] || {};

--- a/simulator/orders.js
+++ b/simulator/orders.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { adjustInventory } from './inventory.js';
 const dataPath = path.join(process.cwd(), 'data', 'orders.json');
 
 function readData() {
@@ -19,6 +20,8 @@ export function createOrder(order) {
   const data = readData();
   data.push(order);
   writeData(data);
+  // deduct inventory from source when the order is placed
+  adjustInventory(order.from, order.item, -order.qty);
   return order;
 }
 


### PR DESCRIPTION
## Summary
- add `getAllInventory` helper and inventory IPC channel
- deduct inventory from source when creating orders
- show inventory via new button and after each step
- document new inventory functionality

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68445ebbf2a4832c825dfa1d0a32b1e5