### PR TITLE
Implement order management with status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ npm start     # launch the desktop app
 ```
 
 Use the buttons in the UI to add a sample entity, advance the simulation
-step, or view current inventory levels. Inventory is automatically reduced
-from the source when an order is placed and added to the destination once
-the order is fulfilled.
+step, or view current inventory levels. You can also create sample orders and
+view their status over time. Inventory is automatically reduced from the
+source when an order is placed and added to the destination once the order is
+fulfilled.
+
+## Order Statuses
+
+Orders move through four statuses during the simulation:
+
+- **pending**: order has been created and is waiting to ship
+- **shipped**: order is in transit
+- **delayed**: shipment is temporarily delayed
+- **received**: order has arrived and inventory is added to the destination

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
   <button id="addEntity">Add Sample Entity</button>
   <button id="nextStep">Next Step</button>
   <button id="viewInventory">View Inventory</button>
+  <button id="addOrder">Add Sample Order</button>
+  <button id="viewOrders">View Orders</button>
   <pre id="output"></pre>
   <canvas id="entityCanvas" width="600" height="400" style="border:1px solid #ccc"></canvas>
   <script type="module" src="renderer.js"></script>

--- a/main.mjs
+++ b/main.mjs
@@ -31,7 +31,7 @@ app.on('window-all-closed', () => {
 });
 
 // IPC handlers bridging to simulator modules
-import { nextStep, addEntity } from './simulator/simulation.js';
+import { nextStep, addEntity, createOrder, getOrders } from './simulator/simulation.js';
 import { getEntities } from './simulator/entities.js';
 import { getAllInventory } from './simulator/inventory.js';
 
@@ -49,4 +49,12 @@ ipcMain.handle('sim:nextStep', () => {
 
 ipcMain.handle('sim:getAllInventory', () => {
   return getAllInventory();
+});
+
+ipcMain.handle('sim:createOrder', (_event, order) => {
+  return createOrder(order);
+});
+
+ipcMain.handle('sim:getOrders', () => {
+  return getOrders();
 });

--- a/preload.cjs
+++ b/preload.cjs
@@ -6,4 +6,6 @@ contextBridge.exposeInMainWorld('api', {
   getEntities: () => ipcRenderer.invoke('sim:getEntities'),
   nextStep: () => ipcRenderer.invoke('sim:nextStep'),
   getAllInventory: () => ipcRenderer.invoke('sim:getAllInventory'),
+  createOrder: (order) => ipcRenderer.invoke('sim:createOrder', order),
+  getOrders: () => ipcRenderer.invoke('sim:getOrders'),
 });

--- a/renderer.js
+++ b/renderer.js
@@ -2,6 +2,8 @@
 const addBtn = document.getElementById('addEntity');
 const stepBtn = document.getElementById('nextStep');
 const inventoryBtn = document.getElementById('viewInventory');
+const addOrderBtn = document.getElementById('addOrder');
+const viewOrdersBtn = document.getElementById('viewOrders');
 const output = document.getElementById('output');
 const canvas = document.getElementById('entityCanvas');
 const ctx = canvas.getContext('2d');
@@ -37,4 +39,17 @@ stepBtn.addEventListener('click', async () => {
 inventoryBtn.addEventListener('click', async () => {
   const inventory = await window.api.getAllInventory();
   output.textContent = JSON.stringify(inventory, null, 2);
+});
+
+addOrderBtn.addEventListener('click', async () => {
+  // create a sample order from supplier1 to retailer1
+  const order = { from: 'supplier1', to: 'retailer1', item: 'item1', qty: 5, delay: 2 };
+  await window.api.createOrder(order);
+  const orders = await window.api.getOrders();
+  output.textContent = JSON.stringify(orders, null, 2);
+});
+
+viewOrdersBtn.addEventListener('click', async () => {
+  const orders = await window.api.getOrders();
+  output.textContent = JSON.stringify(orders, null, 2);
 });

--- a/simulator/simulation.js
+++ b/simulator/simulation.js
@@ -1,4 +1,4 @@
-import { advanceOrders, createOrder } from './orders.js';
+import { advanceOrders, createOrder, getOrders } from './orders.js';
 import { calculateDelay } from './transport.js';
 import { adjustInventory } from './inventory.js';
 import { addEntity as addEntityToStore } from './entities.js';
@@ -23,3 +23,5 @@ export function addEntity(entity) {
   // forward to entities module
   return addEntityToStore(entity);
 }
+
+export { createOrder, getOrders } from './orders.js';


### PR DESCRIPTION
## Summary
- allow creating orders with status tracking
- implement random order delays while advancing orders
- expose order management IPC handlers
- add buttons for creating and viewing orders
- document available order statuses

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68445faafbf8832ca1e3b9feed0da497