### PR TITLE
Display entities on startup

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -20,6 +20,14 @@ function drawEntities(entities) {
   });
 }
 
+async function init() {
+  const entities = await window.api.getEntities();
+  output.textContent = JSON.stringify(entities, null, 2);
+  drawEntities(entities);
+}
+
+window.addEventListener('DOMContentLoaded', init);
+
 addBtn.addEventListener('click', async () => {
   const sample = { id: Date.now().toString(), type: 'warehouse', name: 'Temp Warehouse', location: 'Unknown' };
   await window.api.addEntity(sample);


### PR DESCRIPTION
## Summary
- fetch entities on page load
- show JSON info and draw them immediately

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684461353e74832cbf8ebc80028725c9