### PR TITLE
In-memory data with export/import settings

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -14,6 +14,8 @@ const apiClient = {
   getAllInventory: () => api('GET', '/api/inventory'),
   createOrder: (order) => api('POST', '/api/order', order),
   getOrders: () => api('GET', '/api/orders'),
+  exportData: () => api('GET', '/api/export'),
+  importData: (data) => api('POST', '/api/import', data),
 };
 
 function drawEntities(ctx, canvas, entities) {
@@ -31,6 +33,7 @@ function drawEntities(ctx, canvas, entities) {
 
 function App() {
   const [output, setOutput] = React.useState('');
+  const [importText, setImportText] = React.useState('');
   const canvasRef = React.useRef(null);
 
   const updateEntities = async () => {
@@ -75,16 +78,57 @@ function App() {
     setOutput(JSON.stringify(orders, null, 2));
   };
 
+  const handleExport = async () => {
+    const data = await apiClient.exportData();
+    setOutput(JSON.stringify(data, null, 2));
+  };
+
+  const handleImport = async () => {
+    try {
+      const data = JSON.parse(importText);
+      await apiClient.importData(data);
+      setOutput('Import successful');
+      updateEntities();
+    } catch (e) {
+      setOutput('Invalid JSON');
+    }
+  };
+
   return (
     <div>
       <h1>Supply Chain Simulator</h1>
+
+      <h2>Entity Management</h2>
       <button onClick={handleAddEntity}>Add Sample Entity</button>
+      <button onClick={updateEntities}>Refresh Entities</button>
+
+      <h2>Simulator Controls</h2>
       <button onClick={handleNextStep}>Next Step</button>
       <button onClick={handleViewInventory}>View Inventory</button>
       <button onClick={handleAddOrder}>Add Sample Order</button>
       <button onClick={handleViewOrders}>View Orders</button>
+
+      <h2>Settings</h2>
+      <button onClick={handleExport}>Export Data</button>
+      <div>
+        <textarea
+          rows="4"
+          cols="50"
+          value={importText}
+          onChange={(e) => setImportText(e.target.value)}
+          placeholder="Paste JSON here"
+        />
+      </div>
+      <button onClick={handleImport}>Import Data</button>
+
       <pre>{output}</pre>
-      <canvas ref={canvasRef} id="entityCanvas" width="600" height="400" style={{border: '1px solid #ccc'}}></canvas>
+      <canvas
+        ref={canvasRef}
+        id="entityCanvas"
+        width="600"
+        height="400"
+        style={{ border: '1px solid #ccc' }}
+      ></canvas>
     </div>
   );
 }

--- a/server.mjs
+++ b/server.mjs
@@ -1,9 +1,9 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { addEntity, getEntities } from './simulator/entities.js';
-import { nextStep, createOrder, getOrders } from './simulator/simulation.js';
-import { getAllInventory } from './simulator/inventory.js';
+import { addEntity, getEntities, setEntities } from './simulator/entities.js';
+import { nextStep, createOrder, getOrders, setOrders } from './simulator/simulation.js';
+import { getAllInventory, setAllInventory } from './simulator/inventory.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -38,6 +38,22 @@ app.post('/api/order', (req, res) => {
 
 app.get('/api/orders', (_req, res) => {
   res.json(getOrders());
+});
+
+app.get('/api/export', (_req, res) => {
+  res.json({
+    entities: getEntities(),
+    inventory: getAllInventory(),
+    orders: getOrders(),
+  });
+});
+
+app.post('/api/import', (req, res) => {
+  const { entities, inventory, orders } = req.body || {};
+  if (entities) setEntities(entities);
+  if (inventory) setAllInventory(inventory);
+  if (orders) setOrders(orders);
+  res.json({ status: 'ok' });
 });
 
 app.listen(PORT, () => {

--- a/simulator/entities.js
+++ b/simulator/entities.js
@@ -1,40 +1,40 @@
 import fs from 'fs';
 import path from 'path';
+
 const dataPath = path.join(process.cwd(), 'data', 'entities.json');
 
-function readData() {
-  if (!fs.existsSync(dataPath)) return [];
-  return JSON.parse(fs.readFileSync(dataPath));
+let entities = [];
+
+function loadInitial() {
+  if (fs.existsSync(dataPath)) {
+    entities = JSON.parse(fs.readFileSync(dataPath));
+  }
 }
 
-function writeData(data) {
-  fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
-}
+loadInitial();
 
 export function getEntities() {
-  return readData();
+  return entities;
 }
 
 export function addEntity(entity) {
-  const data = readData();
-  data.push(entity);
-  writeData(data);
+  entities.push(entity);
   return entity;
 }
 
 export function updateEntity(id, partial) {
-  const data = readData();
-  const idx = data.findIndex(e => e.id === id);
+  const idx = entities.findIndex(e => e.id === id);
   if (idx !== -1) {
-    data[idx] = { ...data[idx], ...partial };
-    writeData(data);
-    return data[idx];
+    entities[idx] = { ...entities[idx], ...partial };
+    return entities[idx];
   }
   return null;
 }
 
 export function deleteEntity(id) {
-  const data = readData();
-  const filtered = data.filter(e => e.id !== id);
-  writeData(filtered);
+  entities = entities.filter(e => e.id !== id);
+}
+
+export function setEntities(data) {
+  entities = Array.isArray(data) ? data : [];
 }

--- a/simulator/inventory.js
+++ b/simulator/inventory.js
@@ -1,34 +1,35 @@
 import fs from 'fs';
 import path from 'path';
+
 const dataPath = path.join(process.cwd(), 'data', 'inventory.json');
 
-function readData() {
-  if (!fs.existsSync(dataPath)) return {};
-  return JSON.parse(fs.readFileSync(dataPath));
+let inventory = {};
+
+function loadInitial() {
+  if (fs.existsSync(dataPath)) {
+    inventory = JSON.parse(fs.readFileSync(dataPath));
+  }
 }
 
-function writeData(data) {
-  fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
-}
+loadInitial();
 
 export function getAllInventory() {
-  return readData();
+  return inventory;
 }
 
 export function getInventory(id) {
-  const data = readData();
-  return data[id] || {};
+  return inventory[id] || {};
 }
 
 export function setInventory(id, items) {
-  const data = readData();
-  data[id] = items;
-  writeData(data);
+  inventory[id] = items;
 }
 
 export function adjustInventory(id, item, qty) {
-  const data = readData();
-  if (!data[id]) data[id] = {};
-  data[id][item] = (data[id][item] || 0) + qty;
-  writeData(data);
+  if (!inventory[id]) inventory[id] = {};
+  inventory[id][item] = (inventory[id][item] || 0) + qty;
+}
+
+export function setAllInventory(data) {
+  inventory = data || {};
 }

--- a/simulator/orders.js
+++ b/simulator/orders.js
@@ -1,33 +1,32 @@
 import fs from 'fs';
 import path from 'path';
 import { adjustInventory } from './inventory.js';
+
 const dataPath = path.join(process.cwd(), 'data', 'orders.json');
 
-function readData() {
-  if (!fs.existsSync(dataPath)) return [];
-  return JSON.parse(fs.readFileSync(dataPath));
+let orders = [];
+
+function loadInitial() {
+  if (fs.existsSync(dataPath)) {
+    orders = JSON.parse(fs.readFileSync(dataPath));
+  }
 }
 
-function writeData(data) {
-  fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
-}
+loadInitial();
 
 export function getOrders() {
-  return readData();
+  return orders;
 }
 
 export function createOrder(order) {
-  const data = readData();
   const newOrder = { ...order, status: 'pending' };
-  data.push(newOrder);
-  writeData(data);
+  orders.push(newOrder);
   // deduct inventory from source when the order is placed
   adjustInventory(newOrder.from, newOrder.item, -newOrder.qty);
   return newOrder;
 }
 
 export function advanceOrders() {
-  const orders = readData();
   const remaining = [];
   const fulfilled = [];
   for (const o of orders) {
@@ -53,6 +52,10 @@ export function advanceOrders() {
       remaining.push(o);
     }
   }
-  writeData(remaining);
+  orders = remaining;
   return { remaining, fulfilled };
+}
+
+export function setOrders(data) {
+  orders = Array.isArray(data) ? data : [];
 }

--- a/simulator/simulation.js
+++ b/simulator/simulation.js
@@ -1,4 +1,4 @@
-import { advanceOrders, createOrder, getOrders } from './orders.js';
+import { advanceOrders, createOrder, getOrders, setOrders } from './orders.js';
 import { calculateDelay } from './transport.js';
 import { adjustInventory } from './inventory.js';
 import { addEntity as addEntityToStore } from './entities.js';
@@ -24,4 +24,4 @@ export function addEntity(entity) {
   return addEntityToStore(entity);
 }
 
-export { createOrder, getOrders } from './orders.js';
+export { createOrder, getOrders, setOrders } from './orders.js';


### PR DESCRIPTION
## Summary
- switch data storage to in-memory variables
- add export/import endpoints and settings menu
- include entity management section in UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.mjs` *(fails: Cannot find package 'express' due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684f239329e8832ca20d36afb8240e75